### PR TITLE
Add support for Google Authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Rails API Auth is a lightweight Rails Engine that __implements the _"Resource
 Owner Password Credentials Grant"_ OAuth 2.0 flow
 ([RFC 6749](http://tools.ietf.org/html/rfc6749#section-4.3)) as well as
-Facebook authentication for API projects__.
+Facebook and Google authentication for API projects__.
 
 It uses __Bearer tokens__ ([RFC 6750](http://tools.ietf.org/html/rfc6750)) to
 authorize requests coming in from clients.
@@ -145,10 +145,17 @@ module:
 RailsApiAuth.tap do |raa|
   raa.user_model_relation = :account # this will set up the belongs_to relation from the Login model to the Account model automatically (of course if your application uses a User model this would be :user)
 
+  # Facebook configurations
   raa.facebook_app_id       = '<your Facebook app id>'
   raa.facebook_app_secret   = '<your Facebook app secret>'
   raa.facebook_graph_url    = 'https://graph.facebook.com'
   raa.facebook_redirect_uri = '<your Facebook app redirect uri>'
+
+  # Google configurations
+  raa.google_client_id = '<your Google client id>'
+  raa.google_client_secret = '<your Google client secret>'
+  raa.google_redirect_uri = '<your app redirect uri>'
+
 end
 
 ```

--- a/README.md
+++ b/README.md
@@ -12,13 +12,16 @@ authorize requests coming in from clients.
 
 ## Installation
 
-To install the engine simply add
+To install the engine simply add to the application's `Gemfile`
 
 ```ruby
 gem 'rails_api_auth'
 ```
 
-to the application's `Gemfile` and run `bundle install`.
+ and run:
+```bash
+bundle install
+```
 
 __Rails API Auth also adds a migration__ to the application so run
 
@@ -148,7 +151,6 @@ RailsApiAuth.tap do |raa|
   # Facebook configurations
   raa.facebook_app_id       = '<your Facebook app id>'
   raa.facebook_app_secret   = '<your Facebook app secret>'
-  raa.facebook_graph_url    = 'https://graph.facebook.com'
   raa.facebook_redirect_uri = '<your Facebook app redirect uri>'
 
   # Google configurations

--- a/app/controllers/oauth2_controller.rb
+++ b/app/controllers/oauth2_controller.rb
@@ -11,6 +11,8 @@ class Oauth2Controller < ApplicationController
       authenticate_with_credentials(params[:username], params[:password])
     when 'facebook_auth_code'
       authenticate_with_facebook(params[:auth_code])
+    when 'google_auth_code'
+      authenticate_with_google(params[:auth_code])
     else
       oauth2_error('unsupported_grant_type')
     end
@@ -44,6 +46,16 @@ class Oauth2Controller < ApplicationController
 
       render json: { access_token: login.oauth2_token }
     rescue FacebookAuthenticator::ApiError
+      render nothing: true, status: 502
+    end
+
+    def authenticate_with_google(auth_code)
+      oauth2_error('no_authorization_code') && return unless auth_code.present?
+
+      login = GoogleAuthenticator.new(auth_code).authenticate!
+
+      render json: { access_token: login.oauth2_token }
+    rescue GoogleAuthenticator::ApiError
       render nothing: true, status: 502
     end
 

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -6,11 +6,11 @@
 # The __`Login` model has `identification` and `password` attributes__ (in fact
 # it uses Rails'
 # [`has_secure_password`](http://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password))
-# __as well as a `facebook_uid`__ (if it represents a Facebook login)
+# __as well as a `uid`__ (a Facebook uid or Google sub)
 # attribute. As opposed to the standard `has_secure_password` behavior it
 # doesn't validate that the password must be present but instead validates that
-# __either__ the `password` or the `facebook_uid` are present as no password is
-# required in the case that Facebook is used for authentication.
+# __either__ the `password` or the `uid` are present as no password is
+# required in the case that Facebook or Google is used for authentication.
 #
 # The `Login` model also stores the Bearer token in the `oauth2_token`
 # attribute. The model also stores an additional Bearer token, the
@@ -37,7 +37,7 @@ class Login < ActiveRecord::Base
   validates :oauth2_token, presence: true
   validates :single_use_oauth2_token, presence: true
   validates :password, length: { maximum: 72 }, confirmation: true
-  validate :password_or_facebook_uid_present
+  validate :password_or_uid_present
 
   before_validation :ensure_oauth2_token
   before_validation :assign_single_use_oauth2_token
@@ -70,9 +70,9 @@ class Login < ActiveRecord::Base
 
   private
 
-    def password_or_facebook_uid_present
-      if password_digest.blank? && facebook_uid.blank?
-        errors.add :base, 'either password_digest or facebook_uid must be present'
+    def password_or_uid_present
+      if password_digest.blank? && uid.blank?
+        errors.add :base, 'either password_digest or uid must be present'
       end
     end
 

--- a/app/services/base_authenticator.rb
+++ b/app/services/base_authenticator.rb
@@ -6,4 +6,33 @@ class BaseAuthenticator
     @auth_code = auth_code
   end
 
+  def authenticate!
+    user = get_user(access_token)
+    login = find_login(user)
+
+    if login.present?
+      connect_login_to_account(login, user)
+    else
+      login = create_login_from_account(user)
+    end
+
+    login
+  end
+
+  private
+
+    def find_login(user)
+      Login.where(identification: user[:email]).first
+    end
+
+    def get_request(url)
+      response = HTTParty.get(url)
+      unless response.code == 200
+        Rails.logger.warn "#{self.class::PROVIDER} API request failed with status #{response.code}."
+        Rails.logger.debug "#{self.class::PROVIDER} API error response was:\n#{response.body}"
+        raise ApiError.new
+      end
+      response
+    end
+
 end

--- a/app/services/base_authenticator.rb
+++ b/app/services/base_authenticator.rb
@@ -1,0 +1,9 @@
+class BaseAuthenticator
+
+  class ApiError < StandardError; end
+
+  def initialize(auth_code)
+    @auth_code = auth_code
+  end
+
+end

--- a/app/services/facebook_authenticator.rb
+++ b/app/services/facebook_authenticator.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'pry'
 
 # Handles Facebook authentication
 #
@@ -6,8 +7,8 @@ require 'httparty'
 class FacebookAuthenticator < BaseAuthenticator
 
   PROVIDER = 'facebook'
-  TOKEN_URL = 'https://graph.facebook.com/oauth/access_token?client_id=%{client_id}&client_secret=%{client_secret}&code=%{auth_code}&redirect_uri=%{redirect_uri}'
-  PROFILE_URL = 'https://graph.facebook.com/me?fields=email,name&access_token=%{access_token}'
+  TOKEN_URL = 'https://graph.facebook.com/v2.4/oauth/access_token?client_id=%{client_id}&client_secret=%{client_secret}&code=%{auth_code}&redirect_uri=%{redirect_uri}'
+  PROFILE_URL = 'https://graph.facebook.com/v2.4/me?fields=email,name&access_token=%{access_token}'
 
   private
 
@@ -26,8 +27,8 @@ class FacebookAuthenticator < BaseAuthenticator
     end
 
     def access_token
-      response = get_request(token_url).body
-      response.match(/access_token=([^&]+)/)[1]
+      response = get_request(token_url)
+      response.parsed_response.symbolize_keys[:access_token]
     end
 
     def get_user(access_token)

--- a/app/services/facebook_authenticator.rb
+++ b/app/services/facebook_authenticator.rb
@@ -5,6 +5,8 @@ require 'httparty'
 # @!visibility private
 class FacebookAuthenticator
 
+  PROVIDER = 'facebook'
+
   class ApiError < StandardError; end
 
   def initialize(auth_code)
@@ -28,13 +30,14 @@ class FacebookAuthenticator
     end
 
     def connect_login_to_fb_account
-      login.update_attributes!(facebook_uid: facebook_user[:id])
+      login.update_attributes!(uid: facebook_user[:id], provider: PROVIDER)
     end
 
     def create_login_from_fb_account
       login_attributes = {
         identification: facebook_user[:email],
-        facebook_uid:   facebook_user[:id]
+        uid: facebook_user[:id],
+        provider: PROVIDER
       }
 
       @login = Login.create!(login_attributes)

--- a/app/services/google_authenticator.rb
+++ b/app/services/google_authenticator.rb
@@ -1,0 +1,78 @@
+require 'httparty'
+
+# Handles Google authentication
+#
+# @!visibility private
+class GoogleAuthenticator
+
+  PROVIDER = 'google'
+  TOKEN_URL = 'https://www.googleapis.com/oauth2/v3/token'
+  PROFILE_URL = 'https://www.googleapis.com/plus/v1/people/me/openIdConnect?access_token='
+
+  class ApiError < StandardError; end
+
+  def initialize(auth_code)
+    @auth_code = auth_code
+  end
+
+  def authenticate!
+    if login.present?
+      connect_login_to_google_account
+    else
+      create_login_from_google_account
+    end
+
+    login
+  end
+
+  private
+
+  def login
+    @login ||= Login.where(identification: google_user[:email]).first
+  end
+
+  def connect_login_to_google_account
+    login.update_attributes!(uid: google_user[:sub], provider: PROVIDER)
+  end
+
+  def create_login_from_google_account
+    login_attributes = {
+      identification: google_user[:email],
+      uid: google_user[:sub],
+      provider: PROVIDER
+    }
+
+    @login = Login.create!(login_attributes)
+  end
+
+  def google_user
+    @google_user ||= begin
+      get_request(user_url(access_token)).parsed_response.symbolize_keys
+    end
+  end
+
+  def get_request(url)
+    response = HTTParty.get(url)
+    raise ApiError.new if response.code != 200
+    response
+  end
+
+  def user_url(access_token)
+    "#{PROFILE_URL}#{access_token}"
+  end
+
+  def access_token
+    options = {
+      body: {
+        code: @auth_code,
+        client_id: RailsApiAuth.google_client_id,
+        client_secret: RailsApiAuth.google_client_secret,
+        redirect_uri: RailsApiAuth.google_redirect_uri,
+        grant_type: 'authorization_code'
+      }
+    }
+    response = HTTParty.post(TOKEN_URL, options)
+    response.parsed_response['access_token']
+  end
+
+end

--- a/app/services/google_authenticator.rb
+++ b/app/services/google_authenticator.rb
@@ -27,52 +27,55 @@ class GoogleAuthenticator
 
   private
 
-  def login
-    @login ||= Login.where(identification: google_user[:email]).first
-  end
-
-  def connect_login_to_google_account
-    login.update_attributes!(uid: google_user[:sub], provider: PROVIDER)
-  end
-
-  def create_login_from_google_account
-    login_attributes = {
-      identification: google_user[:email],
-      uid: google_user[:sub],
-      provider: PROVIDER
-    }
-
-    @login = Login.create!(login_attributes)
-  end
-
-  def google_user
-    @google_user ||= begin
-      get_request(user_url(access_token)).parsed_response.symbolize_keys
+    def login
+      @login ||= Login.where(identification: google_user[:email]).first
     end
-  end
 
-  def get_request(url)
-    response = HTTParty.get(url)
-    raise ApiError.new if response.code != 200
-    response
-  end
+    def connect_login_to_google_account
+      login.update_attributes!(uid: google_user[:sub], provider: PROVIDER)
+    end
 
-  def user_url(access_token)
-    "#{PROFILE_URL}#{access_token}"
-  end
-
-  def access_token
-    options = {
-      body: {
-        code: @auth_code,
-        client_id: RailsApiAuth.google_client_id,
-        client_secret: RailsApiAuth.google_client_secret,
-        redirect_uri: RailsApiAuth.google_redirect_uri,
-        grant_type: 'authorization_code'
+    def create_login_from_google_account
+      login_attributes = {
+        identification: google_user[:email],
+        uid: google_user[:sub],
+        provider: PROVIDER
       }
-    }
-    response = HTTParty.post(TOKEN_URL, options)
-    response.parsed_response['access_token']
-  end
+
+      @login = Login.create!(login_attributes)
+    end
+
+    def google_user
+      @google_user ||= begin
+        get_request(user_url(access_token)).parsed_response.symbolize_keys
+      end
+    end
+
+    def get_request(url)
+      response = HTTParty.get(url)
+      raise ApiError.new if response.code != 200
+      response
+    end
+
+    def user_url(access_token)
+      "#{PROFILE_URL}#{access_token}"
+    end
+
+    def access_token
+      response = HTTParty.post(TOKEN_URL, @token_options)
+      response.parsed_response['access_token']
+    end
+
+    def token_options
+      @token_options ||= {
+        body: {
+          code: @auth_code,
+          client_id: RailsApiAuth.google_client_id,
+          client_secret: RailsApiAuth.google_client_secret,
+          redirect_uri: RailsApiAuth.google_redirect_uri,
+          grant_type: 'authorization_code'
+        }
+      }
+    end
 
 end

--- a/app/services/google_authenticator.rb
+++ b/app/services/google_authenticator.rb
@@ -3,17 +3,11 @@ require 'httparty'
 # Handles Google authentication
 #
 # @!visibility private
-class GoogleAuthenticator
+class GoogleAuthenticator < BaseAuthenticator
 
   PROVIDER = 'google'
   TOKEN_URL = 'https://www.googleapis.com/oauth2/v3/token'
-  PROFILE_URL = 'https://www.googleapis.com/plus/v1/people/me/openIdConnect?access_token='
-
-  class ApiError < StandardError; end
-
-  def initialize(auth_code)
-    @auth_code = auth_code
-  end
+  PROFILE_URL = 'https://www.googleapis.com/plus/v1/people/me/openIdConnect?access_token=%{access_token}'
 
   def authenticate!
     if login.present?
@@ -58,7 +52,7 @@ class GoogleAuthenticator
     end
 
     def user_url(access_token)
-      "#{PROFILE_URL}#{access_token}"
+      PROFILE_URL % { access_token: access_token }
     end
 
     def access_token

--- a/app/services/google_authenticator.rb
+++ b/app/services/google_authenticator.rb
@@ -62,7 +62,7 @@ class GoogleAuthenticator
     end
 
     def access_token
-      response = HTTParty.post(TOKEN_URL, @token_options)
+      response = HTTParty.post(TOKEN_URL, token_options)
       response.parsed_response['access_token']
     end
 

--- a/db/migrate/20150904110438_add_provider_to_login.rb
+++ b/db/migrate/20150904110438_add_provider_to_login.rb
@@ -1,6 +1,8 @@
 class AddProviderToLogin < ActiveRecord::Migration
+
   def change
     add_column :logins, :provider, :string
     rename_column :logins, :facebook_uid, :uid
   end
+
 end

--- a/db/migrate/20150904110438_add_provider_to_login.rb
+++ b/db/migrate/20150904110438_add_provider_to_login.rb
@@ -1,0 +1,6 @@
+class AddProviderToLogin < ActiveRecord::Migration
+  def change
+    add_column :logins, :provider, :string
+    rename_column :logins, :facebook_uid, :uid
+  end
+end

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -8,6 +8,7 @@ group :development, :test do
   gem "rspec-rails"
   gem "factory_girl_rails"
   gem "faker"
+  gem "pry-rails"
 end
 
 group :development do

--- a/lib/rails_api_auth.rb
+++ b/lib/rails_api_auth.rb
@@ -20,10 +20,6 @@ module RailsApiAuth
   # The Facebook App secret.
   mattr_accessor :facebook_app_secret
 
-  # @!attribute [rw] facebook_graph_url
-  # The Facebook grahp URL.
-  mattr_accessor :facebook_graph_url
-
   # @!attribute [rw] facebook_redirect_uri
   # The Facebook App's redirect URI.
   mattr_accessor :facebook_redirect_uri

--- a/lib/rails_api_auth.rb
+++ b/lib/rails_api_auth.rb
@@ -28,4 +28,16 @@ module RailsApiAuth
   # The Facebook App's redirect URI.
   mattr_accessor :facebook_redirect_uri
 
+  # @!attribute [rw] google_client_id
+  # The Google client ID.
+  mattr_accessor :google_client_id
+
+  # @!attribute [rw] google_client_secret
+  # The Google client secret.
+  mattr_accessor :google_client_secret
+
+  # @!attribute [rw] google_redirect_uri
+  # The Google App's redirect URI.
+  mattr_accessor :google_redirect_uri
+
 end

--- a/spec/dummy/config/initializers/rails_api_auth.rb
+++ b/spec/dummy/config/initializers/rails_api_auth.rb
@@ -3,7 +3,6 @@ RailsApiAuth.tap do |raa|
 
   raa.facebook_app_id       = 'app_id'
   raa.facebook_app_secret   = 'app_secret'
-  raa.facebook_graph_url    = 'https://graph.facebook.com'
   raa.facebook_redirect_uri = 'redirect_uri'
 
   raa.google_client_id = 'google_client_id'

--- a/spec/dummy/config/initializers/rails_api_auth.rb
+++ b/spec/dummy/config/initializers/rails_api_auth.rb
@@ -5,4 +5,8 @@ RailsApiAuth.tap do |raa|
   raa.facebook_app_secret   = 'app_secret'
   raa.facebook_graph_url    = 'https://graph.facebook.com'
   raa.facebook_redirect_uri = 'redirect_uri'
+
+  raa.google_client_id = 'google_client_id'
+  raa.google_client_secret = 'google_client_secret'
+  raa.google_redirect_uri = 'google_redirect_uri'
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150803185817) do
+ActiveRecord::Schema.define(version: 20150904110438) do
 
   create_table "accounts", force: :cascade do |t|
     t.string   "first_name", null: false
@@ -24,11 +24,12 @@ ActiveRecord::Schema.define(version: 20150803185817) do
     t.string   "identification",          null: false
     t.string   "password_digest"
     t.string   "oauth2_token",            null: false
-    t.string   "facebook_uid"
+    t.string   "uid"
     t.string   "single_use_oauth2_token"
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "provider"
   end
 
 end

--- a/spec/factories/logins.rb
+++ b/spec/factories/logins.rb
@@ -4,8 +4,9 @@ FactoryGirl.define do
     password       { Faker::Lorem.word }
 
     trait :facebook do
-      facebook_uid { Faker::Number.number }
+      uid { Faker::Number.number }
       password nil
+      provider 'facebook'
     end
   end
 end

--- a/spec/models/login_spec.rb
+++ b/spec/models/login_spec.rb
@@ -12,7 +12,7 @@ describe Login do
   end
 
   it "doesn't validate presence of password when Facebook UID is present" do
-    login = described_class.new(identification: 'test@example.com', oauth2_token: 'token', facebook_uid: '123')
+    login = described_class.new(identification: 'test@example.com', oauth2_token: 'token', uid: '123', provider: 'facebook')
 
     expect(login).to be_valid
   end

--- a/spec/requests/oauth2_spec.rb
+++ b/spec/requests/oauth2_spec.rb
@@ -58,7 +58,7 @@ describe 'Oauth2 API' do
         it 'connects the login to the Facebook account' do
           subject
 
-          expect(login.reload.facebook_uid).to eq(facebook_data[:id])
+          expect(login.reload.uid).to eq(facebook_data[:id])
         end
 
         it 'responds with status 200' do

--- a/spec/requests/oauth2_spec.rb
+++ b/spec/requests/oauth2_spec.rb
@@ -48,10 +48,12 @@ describe 'Oauth2 API' do
           email: facebook_email
         }
       end
+      let(:auth_code) { 'authcode' }
+      let(:token_parameters) { { client_id: 'app_id', client_secret: 'app_secret', auth_code: auth_code, redirect_uri: 'redirect_uri' } }
 
       before do
-        stub_request(:get, 'https://graph.facebook.com/oauth/access_token?client_id=app_id&client_secret=app_secret&code=authcode&redirect_uri=redirect_uri').to_return({ body: '{ "access_token": "access_token" }' })
-        stub_request(:get, 'https://graph.facebook.com/me?access_token=access_token').to_return({ body: JSON.generate(facebook_data), headers: { 'Content-Type' => 'application/json' } })
+        stub_request(:get, FacebookAuthenticator::TOKEN_URL % token_parameters).to_return({ body: '{ "access_token": "access_token" }' })
+        stub_request(:get, FacebookAuthenticator::PROFILE_URL % { access_token: 'access_token' }).to_return({ body: JSON.generate(facebook_data), headers: { 'Content-Type' => 'application/json' } })
       end
 
       context 'when a login with for the Facebook account exists' do

--- a/spec/services/facebook_authenticator_spec.rb
+++ b/spec/services/facebook_authenticator_spec.rb
@@ -8,15 +8,17 @@ describe FacebookAuthenticator do
         email: email
       }
     end
-    let(:response_with_fb_token) { { body: '{ "access_token": "access_token" }' } }
-    let(:response_with_fb_user)  { { body: JSON.generate(facebook_data), headers: { 'Content-Type' => 'application/json' } } }
-    let(:login)                  { double('login') }
+    let(:response_with_token) { { body: '{ "access_token": "access_token" }' } }
+    let(:response_with_user)  { { body: JSON.generate(facebook_data), headers: { 'Content-Type' => 'application/json' } } }
+    let(:login) { double('login') }
+
+    let(:token_parameters) { { client_id: 'app_id', client_secret: 'app_secret', auth_code: auth_code, redirect_uri: 'redirect_uri' } }
 
     subject { described_class.new(auth_code).authenticate! }
 
     before do
-      stub_request(:get, 'https://graph.facebook.com/oauth/access_token?client_id=app_id&client_secret=app_secret&code=authcode&redirect_uri=redirect_uri').to_return({ body: '{ "access_token": "access_token" }' })
-      stub_request(:get, 'https://graph.facebook.com/me?access_token=access_token').to_return(response_with_fb_user)
+      stub_request(:get, described_class::TOKEN_URL % token_parameters).to_return(response_with_token)
+      stub_request(:get, described_class::PROFILE_URL % { access_token: 'access_token' }).to_return(response_with_user)
     end
 
     context 'when no login for the Facebook account exists' do

--- a/spec/services/facebook_authenticator_spec.rb
+++ b/spec/services/facebook_authenticator_spec.rb
@@ -23,7 +23,8 @@ describe FacebookAuthenticator do
       let(:login_attributes) do
         {
           identification: facebook_data[:email],
-          facebook_uid:   facebook_data[:id]
+          uid: facebook_data[:id],
+          provider: 'facebook'
         }
       end
 
@@ -39,11 +40,11 @@ describe FacebookAuthenticator do
     context 'when a login for the Facebook account exists already' do
       before do
         expect(Login).to receive(:where).with(identification: facebook_data[:email]).and_return([login])
-        allow(login).to receive(:update_attributes!).with(facebook_uid: facebook_data[:id])
+        allow(login).to receive(:update_attributes!).with(uid: facebook_data[:id], provider: 'facebook')
       end
 
       it 'connects the login to the Facebook account' do
-        expect(login).to receive(:update_attributes!).with(facebook_uid: facebook_data[:id])
+        expect(login).to receive(:update_attributes!).with(uid: facebook_data[:id], provider: 'facebook')
 
         subject
       end

--- a/spec/services/google_authenticator_spec.rb
+++ b/spec/services/google_authenticator_spec.rb
@@ -1,5 +1,3 @@
-require 'webmock/rspec'
-
 describe GoogleAuthenticator do
   describe '#authenticate!' do
     let(:provider) { 'google' }
@@ -18,9 +16,9 @@ describe GoogleAuthenticator do
     subject { described_class.new(auth_code).authenticate! }
 
     before do
-      stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token').
-        with(body: hash_including(grant_type: 'authorization_code')).to_return(body: response_with_token.to_s)
-      stub_request(:get, 'https://www.googleapis.com/plus/v1/people/me/openIdConnect?access_token=access_token').to_return(response_with_user)
+      stub_request(:post, described_class::TOKEN_URL).
+        with(body: hash_including(grant_type: 'authorization_code')).to_return(response_with_token)
+      stub_request(:get, described_class::PROFILE_URL % { access_token: 'access_token' }).to_return(response_with_user)
     end
 
     context 'when no login for the Google account exists' do

--- a/spec/services/google_authenticator_spec.rb
+++ b/spec/services/google_authenticator_spec.rb
@@ -1,0 +1,57 @@
+require 'webmock/rspec'
+
+describe GoogleAuthenticator do
+  describe '#authenticate!' do
+    let(:provider) { 'google' }
+    let(:auth_code) { 'authcode' }
+    let(:email)     { 'email@gmail.com' }
+    let(:google_data) do
+      {
+        sub: '1238190321',
+        email: email
+      }
+    end
+    let(:response_with_token) { { body: '{ "access_token": "access_token" },  "token_type": "Bearer", "expires_in": 3600' } }
+    let(:response_with_user)  { { body: JSON.generate(google_data), headers: { 'Content-Type' => 'application/json' } } }
+    let(:login) { double('login') }
+
+    subject { described_class.new(auth_code).authenticate! }
+
+    before do
+      stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token').
+        with(body: hash_including(grant_type: 'authorization_code')).to_return(body: response_with_token.to_s)
+      stub_request(:get, 'https://www.googleapis.com/plus/v1/people/me/openIdConnect?access_token=access_token').to_return(response_with_user)
+    end
+
+    context 'when no login for the Google account exists' do
+      let(:login_attributes) do
+        {
+          identification: google_data[:email],
+          uid: google_data[:sub],
+          provider: 'google'
+        }
+      end
+
+      before do
+        allow(Login).to receive(:create!).with(login_attributes).and_return(login)
+      end
+
+      it 'returns a login created from the Google account' do
+        expect(subject).to eql(login)
+      end
+    end
+
+    context 'when a login for the Google account exists already' do
+      before do
+        expect(Login).to receive(:where).with(identification: google_data[:email]).and_return([login])
+        allow(login).to receive(:update_attributes!).with(uid: google_data[:sub], provider: provider)
+      end
+
+      it 'connects the login to the Google account' do
+        expect(login).to receive(:update_attributes!).with(uid: google_data[:sub], provider: provider)
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/services/google_authenticator_spec.rb
+++ b/spec/services/google_authenticator_spec.rb
@@ -1,25 +1,18 @@
 describe GoogleAuthenticator do
+  include_context 'stubbed google requests'
   describe '#authenticate!' do
     let(:provider) { 'google' }
-    let(:auth_code) { 'authcode' }
-    let(:email)     { 'email@gmail.com' }
+    let(:email) { 'email@gmail.com' }
     let(:google_data) do
       {
         sub: '1238190321',
         email: email
       }
     end
-    let(:response_with_token) { { body: '{ "access_token": "access_token" },  "token_type": "Bearer", "expires_in": 3600' } }
-    let(:response_with_user)  { { body: JSON.generate(google_data), headers: { 'Content-Type' => 'application/json' } } }
+
     let(:login) { double('login') }
 
     subject { described_class.new(auth_code).authenticate! }
-
-    before do
-      stub_request(:post, described_class::TOKEN_URL).
-        with(body: hash_including(grant_type: 'authorization_code')).to_return(response_with_token)
-      stub_request(:get, described_class::PROFILE_URL % { access_token: 'access_token' }).to_return(response_with_user)
-    end
 
     context 'when no login for the Google account exists' do
       let(:login_attributes) do

--- a/spec/support/shared_contexts/stubbed_facebook_requests.rb
+++ b/spec/support/shared_contexts/stubbed_facebook_requests.rb
@@ -1,9 +1,8 @@
 shared_context 'stubbed facebook requests' do
   let(:auth_code) { 'authcode' }
   let(:access_token)           { 'CAAMvEGOZAxB8BAODGpIWO9meEXEpvigfIRs5j7LIi1Uef8xvTz4vpayfP6rxn0Om3jZAmvEojZB9HNWD44PgSSwFyD7bKsJ3EaNMKwYpZBRqjm25HfwUzF3pOVRXp9cdquT1afm7bj4mnb4WFFo7TxLcgO848FaAKZBdxwefJlPneVUSpquEh2TZAVWghndnPO9ON7QTqXhAZDZD' }
-  let(:response_with_fb_token) { { body: "access_token=#{access_token}&expires=5175490" } }
+  let(:response_with_fb_token) { { body: JSON.generate({ access_token: access_token, token_type: 'bearer', expires_in: 5169402 }), headers: { 'Content-Type' => 'application/json' } } }
   let(:response_with_fb_user)  { { body: JSON.generate(facebook_data), headers: { 'Content-Type' => 'application/json' } } }
-
   let(:token_parameters) { { client_id: 'app_id', client_secret: 'app_secret', auth_code: auth_code, redirect_uri: 'redirect_uri' } }
 
   before do

--- a/spec/support/shared_contexts/stubbed_google_requests.rb
+++ b/spec/support/shared_contexts/stubbed_google_requests.rb
@@ -4,8 +4,8 @@ shared_context 'stubbed google requests' do
   let(:response_with_user)  { { body: JSON.generate(google_data), headers: { 'Content-Type' => 'application/json' } } }
 
   before do
-    stub_request(:post, described_class::TOKEN_URL).
+    stub_request(:post, GoogleAuthenticator::TOKEN_URL).
       with(body: hash_including(grant_type: 'authorization_code')).to_return(response_with_token)
-    stub_request(:get, described_class::PROFILE_URL % { access_token: 'access_token' }).to_return(response_with_user)
+    stub_request(:get, GoogleAuthenticator::PROFILE_URL % { access_token: 'access_token' }).to_return(response_with_user)
   end
 end

--- a/spec/support/shared_contexts/stubbed_google_requests.rb
+++ b/spec/support/shared_contexts/stubbed_google_requests.rb
@@ -1,0 +1,11 @@
+shared_context 'stubbed google requests' do
+  let(:auth_code) { 'authcode' }
+  let(:response_with_token) { { body: '{ "access_token": "access_token" },  "token_type": "Bearer", "expires_in": 3600' } }
+  let(:response_with_user)  { { body: JSON.generate(google_data), headers: { 'Content-Type' => 'application/json' } } }
+
+  before do
+    stub_request(:post, described_class::TOKEN_URL).
+      with(body: hash_including(grant_type: 'authorization_code')).to_return(response_with_token)
+    stub_request(:get, described_class::PROFILE_URL % { access_token: 'access_token' }).to_return(response_with_user)
+  end
+end


### PR DESCRIPTION
I've implemented support for Google Authentication, please review and let me know your thoughts.
In order to support both Facebook and Google a new column 'provider' was added.
The 'facebook_uid' column was renamed to uid and represent an Facebook uid or Google sud.