### PR TITLE
Fix engine name

### DIFF
--- a/lib/rails_api_auth/engine.rb
+++ b/lib/rails_api_auth/engine.rb
@@ -3,6 +3,8 @@ module RailsApiAuth
   # @!visibility private
   class Engine < ::Rails::Engine
 
+    engine_name 'rails_api_auth'
+
     initializer :append_migrations do |app|
       unless app.root.to_s.match root.to_s
         config.paths['db/migrate'].expanded.each do |expanded_path|


### PR DESCRIPTION
rails_api_auth_engine (default) -> rails_api_auth

This means if you are e.g installing migrations you can run:

    rake rails_api_auth:install:migrations

As opposed to `rake rails_api_auth_engine:install:migrations` which you
probably wouldn’t guess.