### PR TITLE
Remove pry from facebook connector, as it used only in development.

### DIFF
--- a/app/services/facebook_authenticator.rb
+++ b/app/services/facebook_authenticator.rb
@@ -1,5 +1,4 @@
 require 'httparty'
-require 'pry'
 
 # Handles Facebook authentication
 #


### PR DESCRIPTION
There's a lost require in the facebook authenticator, as reported by #30 

Still need to require HTTParty, because otherwise tests will fail.