### PR TITLE
force_ssl with tests

### DIFF
--- a/app/controllers/oauth2_controller.rb
+++ b/app/controllers/oauth2_controller.rb
@@ -5,6 +5,9 @@ require 'login_not_found'
 # @!visibility private
 class Oauth2Controller < ApplicationController
 
+  # Default to forcing SSL unless disabled
+  force_ssl if: -> { RailsApiAuth.force_ssl.nil? || RailsApiAuth.force_ssl }
+
   def create
     case params[:grant_type]
     when 'password'

--- a/app/services/facebook_authenticator.rb
+++ b/app/services/facebook_authenticator.rb
@@ -1,5 +1,3 @@
-require 'httparty'
-
 # Handles Facebook authentication
 #
 # @!visibility private

--- a/app/services/google_authenticator.rb
+++ b/app/services/google_authenticator.rb
@@ -1,5 +1,3 @@
-require 'httparty'
-
 # Handles Google authentication
 #
 # @!visibility private

--- a/lib/rails_api_auth.rb
+++ b/lib/rails_api_auth.rb
@@ -16,6 +16,10 @@ module RailsApiAuth
   # The Facebook App ID.
   mattr_accessor :facebook_app_id
 
+  # @!attribute [rw] force_ssl
+  # Force SSL for Oauth2Controller.
+  mattr_accessor :force_ssl
+
   # @!attribute [rw] facebook_app_secret
   # The Facebook App secret.
   mattr_accessor :facebook_app_secret

--- a/lib/rails_api_auth/engine.rb
+++ b/lib/rails_api_auth/engine.rb
@@ -1,3 +1,4 @@
+require 'httparty'
 require 'rails_api_auth/authentication'
 
 module RailsApiAuth

--- a/spec/requests/oauth2_spec.rb
+++ b/spec/requests/oauth2_spec.rb
@@ -9,25 +9,25 @@ describe 'Oauth2 API' do
     subject { post '/token', params }
 
     context 'force_ssl' do
-        it 'responds with status 301 when not specified' do
-          RailsApiAuth.force_ssl = nil
-          subject
-          expect(response).to have_http_status(301)
-        end
+      it 'responds with status 301 when not specified' do
+        RailsApiAuth.force_ssl = nil
+        subject
+        expect(response).to have_http_status(301)
+      end
 
-        it 'responds with status 301 when set to true' do
-          RailsApiAuth.force_ssl = true
-          subject
-          expect(response).to have_http_status(301)
-        end
+      it 'responds with status 301 when set to true' do
+        RailsApiAuth.force_ssl = true
+        subject
+        expect(response).to have_http_status(301)
+      end
 
-        it 'responds with status 200 when set to false' do
-          RailsApiAuth.force_ssl = false
-          subject
-          expect(response).to have_http_status(200)
-        end
+      it 'responds with status 200 when set to false' do
+        RailsApiAuth.force_ssl = false
+        subject
+        expect(response).to have_http_status(200)
+      end
     end
-    
+
     context 'for grant_type "password"' do
       context 'with valid login credentials' do
         it 'responds with status 200' do

--- a/spec/requests/oauth2_spec.rb
+++ b/spec/requests/oauth2_spec.rb
@@ -1,11 +1,33 @@
 describe 'Oauth2 API' do
   let!(:login) { create(:login) }
 
+  before { RailsApiAuth.force_ssl = false }
+
   describe 'POST /token' do
     let(:params) { { grant_type: 'password', username: login.identification, password: login.password } }
 
     subject { post '/token', params }
 
+    context 'force_ssl' do
+        it 'responds with status 301 when not specified' do
+          RailsApiAuth.force_ssl = nil
+          subject
+          expect(response).to have_http_status(301)
+        end
+
+        it 'responds with status 301 when set to true' do
+          RailsApiAuth.force_ssl = true
+          subject
+          expect(response).to have_http_status(301)
+        end
+
+        it 'responds with status 200 when set to false' do
+          RailsApiAuth.force_ssl = false
+          subject
+          expect(response).to have_http_status(200)
+        end
+    end
+    
     context 'for grant_type "password"' do
       context 'with valid login credentials' do
         it 'responds with status 200' do


### PR DESCRIPTION
This PR addresses https://github.com/simplabs/rails_api_auth/issues/29

A few comments:

1. The default is `force_ssl` like Marco requested
2. I am setting it to `false` so that the existing tests should pass
3. I am testing that when `force_ssl` is set to true or not set (default) - I get back a 301