### PR TITLE
Rails 5.1 Migration Compatibility

### DIFF
--- a/db/migrate/20150709221755_create_logins.rb
+++ b/db/migrate/20150709221755_create_logins.rb
@@ -1,4 +1,4 @@
-class CreateLogins < ActiveRecord::Migration
+class CreateLogins < ActiveRecord::Migration[4.2]
 
   def change
     create_table :logins, primary_key_options(:id) do |t|

--- a/db/migrate/20150904110438_add_provider_to_login.rb
+++ b/db/migrate/20150904110438_add_provider_to_login.rb
@@ -1,4 +1,4 @@
-class AddProviderToLogin < ActiveRecord::Migration
+class AddProviderToLogin < ActiveRecord::Migration[4.2]
 
   def change
     add_column :logins, :provider, :string


### PR DESCRIPTION
Inheriting from ActiveRecord::Migrations directly is deprecated in Rails 5.1. With this change, it should work with Rails 4.2 and above.

closes #62 