### PR TITLE
Rails 5.1 Migration Compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Rails/ApplicationRecord:
 Rails/Blank:
   Enabled: false
 
+Rails/InverseOf:
+  Enabled: false
+
 Style/BlockDelimiters:
   Exclude:
     - 'spec/**/*'

--- a/db/migrate/20150709221755_create_logins.rb
+++ b/db/migrate/20150709221755_create_logins.rb
@@ -1,4 +1,4 @@
-class CreateLogins < ActiveRecord::Migration
+class CreateLogins < ActiveRecord::Migration[4.2]
 
   def change
     create_table :logins, primary_key_options(:id) do |t|

--- a/db/migrate/20150709221755_create_logins.rb
+++ b/db/migrate/20150709221755_create_logins.rb
@@ -1,4 +1,6 @@
-class CreateLogins < ActiveRecord::Migration[4.2]
+require_relative 'rails_api_auth_migration'
+
+class CreateLogins < RailsAPIAuthMigration
 
   def change
     create_table :logins, primary_key_options(:id) do |t|

--- a/db/migrate/20150904110438_add_provider_to_login.rb
+++ b/db/migrate/20150904110438_add_provider_to_login.rb
@@ -1,4 +1,4 @@
-class AddProviderToLogin < ActiveRecord::Migration
+class AddProviderToLogin < ActiveRecord::Migration[4.2]
 
   def change
     add_column :logins, :provider, :string

--- a/db/migrate/20150904110438_add_provider_to_login.rb
+++ b/db/migrate/20150904110438_add_provider_to_login.rb
@@ -1,4 +1,6 @@
-class AddProviderToLogin < ActiveRecord::Migration[4.2]
+require_relative 'rails_api_auth_migration'
+
+class AddProviderToLogin < RailsAPIAuthMigration
 
   def change
     add_column :logins, :provider, :string

--- a/db/migrate/rails_api_auth_migration.rb
+++ b/db/migrate/rails_api_auth_migration.rb
@@ -1,7 +1,9 @@
-migration_parent_class = if Rails.version >= '5.0.0'
-  ActiveRecord::Migration["#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"]
-else
-  ActiveRecord::Migration
+private def migration_parent_class
+  if Rails.version >= '5.0.0'
+    ActiveRecord::Migration["#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"]
+  else
+    ActiveRecord::Migration
+  end
 end
 
 class RailsAPIAuthMigration < migration_parent_class

--- a/db/migrate/rails_api_auth_migration.rb
+++ b/db/migrate/rails_api_auth_migration.rb
@@ -1,0 +1,8 @@
+migration_parent_class = if Rails.version >= '5.0.0'
+  ActiveRecord::Migration["#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"]
+else
+  ActiveRecord::Migration
+end
+
+class RailsAPIAuthMigration < migration_parent_class
+end

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -32,7 +32,7 @@ platforms :ruby, :mswin, :mingw do
 end
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter"
+  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.24"
 end
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -32,7 +32,7 @@ platforms :ruby, :mswin, :mingw do
 end
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter"
+  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.24"
 end
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -33,8 +33,7 @@ platforms :ruby, :mswin, :mingw do
 end
 
 platforms :jruby do
-  # Rails 5 support is not in master. See: https://github.com/jruby/activerecord-jdbc-adapter/issues/700
-  gem 'activerecord-jdbcsqlite3-adapter', git: 'https://github.com/jruby/activerecord-jdbc-adapter.git', branch: 'rails-5'
+  gem 'activerecord-jdbcsqlite3-adapter'
 end
 
 gemspec :path => "../"

--- a/rails_api_auth.gemspec
+++ b/rails_api_auth.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files      = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency('rails', '>= 3.2.6', '< 6')
   s.add_dependency('bcrypt', '~> 3.1.7')
   s.add_dependency('httparty', '~> 0.13.3')
+  s.add_dependency('rails', '>= 3.2.6', '< 6')
 end

--- a/spec/dummy/db/migrate/20150803185817_create_accounts.rb
+++ b/spec/dummy/db/migrate/20150803185817_create_accounts.rb
@@ -1,4 +1,6 @@
-class CreateAccounts < ActiveRecord::Migration
+require_relative '../../../../db/migrate/rails_api_auth_migration'
+
+class CreateAccounts < RailsAPIAuthMigration
 
   def change
     create_table :accounts do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -14,22 +13,23 @@
 ActiveRecord::Schema.define(version: 20150904110438) do
 
   create_table "accounts", force: :cascade do |t|
-    t.string   "first_name", null: false
-    t.string   "last_name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string "first_name", null: false
+    t.string "last_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "logins", force: :cascade do |t|
-    t.string   "identification",          null: false
-    t.string   "password_digest"
-    t.string   "oauth2_token",            null: false
-    t.string   "uid"
-    t.string   "single_use_oauth2_token"
-    t.integer  "user_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "provider"
+    t.string "identification", null: false
+    t.string "password_digest"
+    t.string "oauth2_token", null: false
+    t.string "uid"
+    t.string "single_use_oauth2_token"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "provider"
+    t.index ["user_id"], name: "index_logins_on_user_id"
   end
 
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -8,28 +9,37 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended that you check this file into your version control system.
+# It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150904110438) do
+ActiveRecord::Schema.define(:version => 20150904110438) do
 
-  create_table "accounts", force: :cascade do |t|
-    t.string "first_name", null: false
-    t.string "last_name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "accounts", :force => true do |t|
+    t.string   "first_name", :limit => nil, :null => false
+    t.string   "last_name",  :limit => nil
+    t.datetime "created_at",                :null => false
+    t.datetime "updated_at",                :null => false
   end
 
-  create_table "logins", force: :cascade do |t|
-    t.string "identification", null: false
-    t.string "password_digest"
-    t.string "oauth2_token", null: false
-    t.string "uid"
-    t.string "single_use_oauth2_token"
-    t.integer "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "provider"
-    t.index ["user_id"], name: "index_logins_on_user_id"
+  create_table "ar_internal_metadata", :primary_key => "key", :force => true do |t|
+    t.string   "value",      :limit => nil
+    t.datetime "created_at",                :null => false
+    t.datetime "updated_at",                :null => false
   end
+
+  add_index "ar_internal_metadata", ["key"], :name => "sqlite_autoindex_ar_internal_metadata_1", :unique => true
+
+  create_table "logins", :force => true do |t|
+    t.string   "identification",          :limit => nil, :null => false
+    t.string   "password_digest",         :limit => nil
+    t.string   "oauth2_token",            :limit => nil, :null => false
+    t.string   "uid",                     :limit => nil
+    t.string   "single_use_oauth2_token", :limit => nil
+    t.integer  "user_id"
+    t.datetime "created_at",                             :null => false
+    t.datetime "updated_at",                             :null => false
+    t.string   "provider",                :limit => nil
+  end
+
+  add_index "logins", ["user_id"], :name => "index_logins_on_user_id"
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 
 require 'simplecov'
-SimpleCov.start do ||
+SimpleCov.start do
   unless defined?(JRUBY_VERSION) || defined?(JRuby)
     minimum_coverage 95
     refuse_coverage_drop


### PR DESCRIPTION
Inheriting from ActiveRecord::Migrations directly is deprecated in Rails 5.1. With this change, it should work with Rails 3 and above.

replaces #61 
closes #62 