### PR TITLE
[WIP] allow custom grant type handlers

### DIFF
--- a/lib/rails_api_auth.rb
+++ b/lib/rails_api_auth.rb
@@ -74,4 +74,8 @@ module RailsApiAuth
   mattr_accessor :force_ssl
   self.force_ssl = !Rails.env.development?
 
+  # @!attribute [rw] custom_providers
+  # Mapping of custom grant types to provider implementations
+  mattr_accessor :custom_providers
+
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -9,37 +8,28 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150904110438) do
+ActiveRecord::Schema.define(version: 20150904110438) do
 
-  create_table "accounts", :force => true do |t|
-    t.string   "first_name", :limit => nil, :null => false
-    t.string   "last_name",  :limit => nil
-    t.datetime "created_at",                :null => false
-    t.datetime "updated_at",                :null => false
+  create_table "accounts", force: :cascade do |t|
+    t.string   "first_name", null: false
+    t.string   "last_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "ar_internal_metadata", :primary_key => "key", :force => true do |t|
-    t.string   "value",      :limit => nil
-    t.datetime "created_at",                :null => false
-    t.datetime "updated_at",                :null => false
-  end
-
-  add_index "ar_internal_metadata", ["key"], :name => "sqlite_autoindex_ar_internal_metadata_1", :unique => true
-
-  create_table "logins", :force => true do |t|
-    t.string   "identification",          :limit => nil, :null => false
-    t.string   "password_digest",         :limit => nil
-    t.string   "oauth2_token",            :limit => nil, :null => false
-    t.string   "uid",                     :limit => nil
-    t.string   "single_use_oauth2_token", :limit => nil
+  create_table "logins", force: :cascade do |t|
+    t.string   "identification",          null: false
+    t.string   "password_digest"
+    t.string   "oauth2_token",            null: false
+    t.string   "uid"
+    t.string   "single_use_oauth2_token"
     t.integer  "user_id"
-    t.datetime "created_at",                             :null => false
-    t.datetime "updated_at",                             :null => false
-    t.string   "provider",                :limit => nil
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.string   "provider"
+    t.index ["user_id"], name: "index_logins_on_user_id"
   end
-
-  add_index "logins", ["user_id"], :name => "index_logins_on_user_id"
 
 end


### PR DESCRIPTION
This adds support for implementing custom authenticators for supporting custom grant types. This is only the first stab at the feature and likely needs some cleanup and tuning but should be functional already.